### PR TITLE
Update Nokogiri to 1.16.2 for security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.9.0] - 2024-02-20
+
+- Update Nokogiri for security vulnerability
+
 ## [0.8.2] - 2023-12-05
 
 - Update documentation and links to point to new GitHub repo at CompanyCam.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,15 +36,15 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     minitest (5.20.0)
-    nokogiri (1.15.4-arm64-darwin)
+    nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    racc (1.7.1)
+    racc (1.7.3)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tiptap-ruby (0.8.2)
+    tiptap-ruby (0.9.0)
       actionview (>= 6.0)
       activesupport (>= 6.0)
 

--- a/lib/tip_tap/version.rb
+++ b/lib/tip_tap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TipTap
-  VERSION = "0.8.2"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
There is a security vulnerability with nokogiri that needs to be patched by updating the version.

https://github.com/CompanyCam/tiptap-ruby/security/dependabot/1