### PR TITLE
Failing specs to show how separator impacts marks

### DIFF
--- a/spec/tip_tap/node_spec.rb
+++ b/spec/tip_tap/node_spec.rb
@@ -89,5 +89,53 @@ RSpec.describe TipTap::Node do
       expect(text).to be_a(String)
       expect(text).to eq("Hello World!")
     end
+
+    context "when the node has children" do
+      it "breaks up paragraphs with separator" do
+        node = TipTap::Node.from_json({
+          content: [
+            {type: "paragraph", content: [type: "text", text: "Hello World!"]},
+            {type: "paragraph", content: [type: "text", text: "How are you?"]}
+          ]
+        })
+        text = node.to_plain_text(separator: "\n\n")
+        expect(text).to be_a(String)
+        expect(text).to eq("Hello World!\n\nHow are you?")
+      end
+
+      it "does not break up links with separator" do
+        node = TipTap::Node.from_json({
+          content: [
+            {
+              type: "paragraph", content: [
+                {type: "text", text: "Hello "},
+                {type: "text", text: "World!", marks: [{type: "link", attrs: {href: "https://example.com"}}]}
+              ]
+            },
+            {type: "paragraph", content: [type: "text", text: "How are you?"]}
+          ]
+        })
+        text = node.to_plain_text(separator: "\n\n")
+        expect(text).to be_a(String)
+        expect(text).to eq("Hello World!\n\nHow are you?")
+      end
+
+      it "does not break up bold marks with separator" do
+        node = TipTap::Node.from_json({
+          content: [
+            {
+              type: "paragraph", content: [
+                {type: "text", text: "Hello "},
+                {type: "text", text: "World!", marks: [{type: "bold"}]}
+              ]
+            },
+            {type: "paragraph", content: [type: "text", text: "How are you?"]}
+          ]
+        })
+        text = node.to_plain_text(separator: "\n\n")
+        expect(text).to be_a(String)
+        expect(text).to eq("Hello World!\n\nHow are you?")
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey, thanks for the library.
I hit a few gotchas in the conversion to plain text that doesn't match Tiptap.js. I wrote these failing specs and I was looking into coding for them but realized it would go far beyond just solving this for a few types of mark nodes. Are you looking for this ruby implementation to match the JS behavior when converting to plain text?