### PR TITLE
Release: add platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 


### PR DESCRIPTION
I need to add a platform to gemfile.lock in order to release 🤦 

<img width="587" alt="image" src="https://github.com/CompanyCam/tiptap-ruby/assets/12461490/58cfbcd1-c175-4538-9e4e-5320c0210ff0">
