### PR TITLE
Fix converting paragraphs to plain text

### DIFF
--- a/lib/tip_tap/nodes/paragraph.rb
+++ b/lib/tip_tap/nodes/paragraph.rb
@@ -11,6 +11,13 @@ module TipTap
       def text(text, marks: [])
         add_content(Text.new(text, marks: marks))
       end
+
+      # Override the default to_plain_text method to account for the nested Text nodes
+      # we don't want to use the separator when joining the text nodes since it could
+      # be a newline or some other character that we don't want to include in the plain text
+      def to_plain_text(separator: " ")
+        content.map { |node| node.to_plain_text(separator: separator) }.join("")
+      end
     end
   end
 end

--- a/spec/tip_tap/node_spec.rb
+++ b/spec/tip_tap/node_spec.rb
@@ -89,5 +89,53 @@ RSpec.describe TipTap::Node do
       expect(text).to be_a(String)
       expect(text).to eq("Hello World!")
     end
+
+    context "when the node has children" do
+      it "breaks up paragraphs with separator" do
+        node = TipTap::Node.from_json({
+          content: [
+            {type: "paragraph", content: [type: "text", text: "Hello World!"]},
+            {type: "paragraph", content: [type: "text", text: "How are you?"]}
+          ]
+        })
+        text = node.to_plain_text(separator: "\n\n")
+        expect(text).to be_a(String)
+        expect(text).to eq("Hello World!\n\nHow are you?")
+      end
+
+      it "does not break up links with separator" do
+        node = TipTap::Node.from_json({
+          content: [
+            {
+              type: "paragraph", content: [
+                {type: "text", text: "Hello "},
+                {type: "text", text: "World!", marks: [{type: "link", attrs: {href: "https://example.com"}}]}
+              ]
+            },
+            {type: "paragraph", content: [type: "text", text: "How are you?"]}
+          ]
+        })
+        text = node.to_plain_text(separator: "\n\n")
+        expect(text).to be_a(String)
+        expect(text).to eq("Hello World!\n\nHow are you?")
+      end
+
+      it "does not break up bold marks with separator" do
+        node = TipTap::Node.from_json({
+          content: [
+            {
+              type: "paragraph", content: [
+                {type: "text", text: "Hello "},
+                {type: "text", text: "World!", marks: [{type: "bold"}]}
+              ]
+            },
+            {type: "paragraph", content: [type: "text", text: "How are you?"]}
+          ]
+        })
+        text = node.to_plain_text(separator: "\n\n")
+        expect(text).to be_a(String)
+        expect(text).to eq("Hello World!\n\nHow are you?")
+      end
+    end
   end
 end

--- a/spec/tip_tap_spec.rb
+++ b/spec/tip_tap_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe TipTap do
     end
 
     it "parses the json and returns the plain text" do
+      puts document.to_plain_text
       expect(document.to_plain_text).to eq(
-        "Site Summary Overview -  May 2nd 2023  This is a site visit summary that is being  synthesized  by  Chad Wilken.  Todo 1 Todo 2 Todo 3  This is a heading 2 This is a heading 3  This is a bullet item This is  another item Final paragraph."
+        "Site Summary Overview -  May 2nd 2023  This is a site visit summary that is being synthesized by Chad Wilken.  Todo 1 Todo 2 Todo 3  This is a heading 2 This is a heading 3  This is a bullet item This is another item Final paragraph."
       )
     end
 

--- a/spec/tip_tap_spec.rb
+++ b/spec/tip_tap_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe TipTap do
     end
 
     it "parses the json and returns the plain text" do
-      puts document.to_plain_text
       expect(document.to_plain_text).to eq(
         "Site Summary Overview -  May 2nd 2023  This is a site visit summary that is being synthesized by Chad Wilken.  Todo 1 Todo 2 Todo 3  This is a heading 2 This is a heading 3  This is a bullet item This is another item Final paragraph."
       )


### PR DESCRIPTION
### Description
A user of the gem opened [a PR](https://github.com/CompanyCam/tiptap-ruby/pull/14) with an example spec for how joining text should work. I used that spec as the basis for fixing the `Paragraph` node joining behavior for child `Text` nodes.

### Reason
This is probably the correct behavior.

### Testing
RSpec