### PR TITLE
Always include text while using to_h

### DIFF
--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -22,7 +22,9 @@ module TipTap
       end
 
       def to_h
-        {type: type_name, text: text, marks: marks.map(&:deep_symbolize_keys)}.compact_blank
+        data = {type: type_name, text: text.presence || ""}
+        data[:marks] = marks.map(&:deep_symbolize_keys) unless marks.empty?
+        data
       end
 
       def to_html


### PR DESCRIPTION
### Description
If the `text` attribute is `nil` then the call to `compact_blank` removes the `text` key from the hash. It turns out that makes the TipTap Document invalid when parsed by the JS library.

### Reason/Reference
We should always include text, even if an empty string.
