### PR TITLE
Bump rexml to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,8 +55,8 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)


### PR DESCRIPTION
### Description
Fix the dependabot vulnerability report https://github.com/CompanyCam/tiptap-ruby/security/dependabot/5 by updating rexml.

### Reason/Reference
Security update for rexml
