### PR TITLE
Add support for additional image attributes

### DIFF
--- a/lib/tip_tap/nodes/image.rb
+++ b/lib/tip_tap/nodes/image.rb
@@ -12,7 +12,7 @@ module TipTap
       end
 
       def to_html
-        image_tag(src)
+        image_tag(src, attrs.except("src"))
       end
 
       def src

--- a/lib/tip_tap/nodes/image.rb
+++ b/lib/tip_tap/nodes/image.rb
@@ -12,7 +12,11 @@ module TipTap
       end
 
       def to_html
-        image_tag(src, attrs.except("src"))
+        image_tag(src, alt: alt)
+      end
+
+      def alt
+        attrs["alt"]
       end
 
       def src

--- a/spec/tip_tap/nodes/image_spec.rb
+++ b/spec/tip_tap/nodes/image_spec.rb
@@ -11,10 +11,18 @@ RSpec.describe TipTap::Nodes::Image do
       expect(html).to be_a(String)
       expect(html).to eq('<img src="https://img.companycam.com/abcd1234.jpeg" />')
     end
+
+    it "optionally returns additional attributes" do
+      node = TipTap::Nodes::Image.new(src: "https://img.companycam.com/abcd1234.jpeg", alt: "Alt text example")
+      html = node.to_html
+
+      expect(html).to be_a(String)
+      expect(html).to eq('<img alt="Alt text example" src="https://img.companycam.com/abcd1234.jpeg" />')
+    end
   end
 
   describe "src" do
-    it "returns a the src attribute" do
+    it "returns the src attribute" do
       node = TipTap::Nodes::Image.new(src: "https://img.companycam.com/abcd1234.jpeg")
       expect(node.src).to eq("https://img.companycam.com/abcd1234.jpeg")
     end


### PR DESCRIPTION
### Description
Adds support for setting additional attributes beyond `src` on the image node HTML output.

### Reason/Reference
Currently the implementation doesn't allow for alt text (or any other attribute) to be set.

—

Thanks for the excellent work on this gem!