### PR TITLE
Update rexml to 3.3.4 for CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rspec (3.12.0)
       rspec-core (~> 3.12.0)


### PR DESCRIPTION
### Description
Update rexml to close https://github.com/CompanyCam/tiptap-ruby/security/dependabot/7 and https://github.com/CompanyCam/tiptap-ruby/security/dependabot/6.

### Reason/Reference
Security
