### PR TITLE
Update rexml for CVE-2024-43398

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.2)
-    rexml (3.3.4)
+    rexml (3.3.6)
       strscan
     rspec (3.12.0)
       rspec-core (~> 3.12.0)


### PR DESCRIPTION
### Description
Update rexml for https://github.com/CompanyCam/tiptap-ruby/security/dependabot/8.

### Reason/Reference
Security maintenance
