### PR TITLE
Preserve whitespace in text nodes

### DIFF
--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -22,7 +22,7 @@ module TipTap
       end
 
       def to_h
-        data = {type: type_name, text: text}
+        data = {type: type_name, text: text || ""}
         data[:marks] = marks.map(&:deep_symbolize_keys) unless marks.empty?
         data
       end

--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -22,7 +22,7 @@ module TipTap
       end
 
       def to_h
-        data = {type: type_name, text: text.presence || ""}
+        data = {type: type_name, text: text}
         data[:marks] = marks.map(&:deep_symbolize_keys) unless marks.empty?
         data
       end

--- a/spec/tip_tap/nodes/text_spec.rb
+++ b/spec/tip_tap/nodes/text_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe TipTap::Nodes::Text do
   end
 
   describe "to_h" do
-     context "with marks" do
+    context "with marks" do
       it "returns a JSON object with marks" do
         node = TipTap::Nodes::Text.new("Hello World!", marks: [{type: "bold"}, {type: "italic"}])
         json = node.to_h

--- a/spec/tip_tap/nodes/text_spec.rb
+++ b/spec/tip_tap/nodes/text_spec.rb
@@ -136,11 +136,22 @@ RSpec.describe TipTap::Nodes::Text do
   end
 
   describe "to_h" do
-    it "returns a JSON object" do
-      node = TipTap::Nodes::Text.new("Hello World!", marks: [{type: "bold"}, {type: "italic"}])
-      json = node.to_h
+     context "with marks" do
+      it "returns a JSON object with marks" do
+        node = TipTap::Nodes::Text.new("Hello World!", marks: [{type: "bold"}, {type: "italic"}])
+        json = node.to_h
 
-      expect(json).to eq({type: "text", text: "Hello World!", marks: [{type: "bold"}, {type: "italic"}]})
+        expect(json).to eq({type: "text", text: "Hello World!", marks: [{type: "bold"}, {type: "italic"}]})
+      end
+    end
+
+    context "whitespace" do
+      it "returns a JSON object that preserves whitespace" do
+        node = TipTap::Nodes::Text.new(" ")
+        json = node.to_h
+
+        expect(json).to eq({type: "text", text: " "})
+      end
     end
   end
 end


### PR DESCRIPTION
### Description
Pass the `text` from a text node directly to the JSON created via `to_h` instead of stripping out whitespace only strings.

### Reason/Reference
Text nodes that just contain whitespace have a valid use case, such as separating out two text nodes with marks. This currently prevents you from having a space between two link nodes, for example.

#### Example
The message...
> I would like a [banana](https://en.wikipedia.org/wiki/Banana) [milkshake](https://en.wikipedia.org/wiki/Milkshake)

Should have four JSON text nodes that look like...
```
...
{ type: "text", text: "I would like a " },
{ type: "text", text: "banana", marks: [LINK MARKS] },
{ type: "text", text: " " },
{ type: "text", text: "milkshake", marks: [LINK MARKS] }
...
```

...but the current implementation returns...
```
...
{ type: "text", text: "I would like a " },
{ type: "text", text: "banana", marks: [LINK MARKS] },
{ type: "text", text: "" },
{ type: "text", text: "milkshake", marks: [LINK MARKS] }
...
```

... which would mean if we pass the JSON to an editor we would get:
> I would like a [banana](https://en.wikipedia.org/wiki/Banana)[milkshake](https://en.wikipedia.org/wiki/Milkshake)

... instead of what we expected.

      
