### PR TITLE
Adding support for tables

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -1,0 +1,62 @@
+name: Publish Gem
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_and_publish:
+    name: Build, tag & publish
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.1
+
+    - name: Get version
+      id: version
+      run: |
+        VERSION=$(ruby -e "require './lib/tip_tap/version'; puts TipTap::VERSION")
+        echo "::set-output name=version::$VERSION"
+
+    - name: Create and push tag
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git tag v${{ steps.version.outputs.version }}
+        git push origin v${{ steps.version.outputs.version }}
+
+    - name: Run tests
+      run: |
+        bundle install
+        bundle exec rspec
+
+    - name: Build and publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_API_KEY}}"
+
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.version.outputs.version }}
+        release_name: Release ${{ steps.version.outputs.version }}
+        body: |
+          See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md) for details.
+        draft: false
+        prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.9.8] - 2024-09-10
+
+- Table support (Table, TableRow, TableCell, TableHeader)
+
 ## [0.9.6] - 2024-08-06
 
 - Bump rexml version to 3.3.4 for CVE

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tiptap-ruby (0.9.7)
+    tiptap-ruby (0.9.8)
       actionview (>= 6.0)
       activesupport (>= 6.0)
 

--- a/lib/tip_tap.rb
+++ b/lib/tip_tap.rb
@@ -16,6 +16,10 @@ require "tip_tap/nodes/text"
 require "tip_tap/nodes/image"
 require "tip_tap/nodes/blockquote"
 require "tip_tap/nodes/codeblock"
+require "tip_tap/nodes/table"
+require "tip_tap/nodes/table_row"
+require "tip_tap/nodes/table_cell"
+require "tip_tap/nodes/table_header"
 
 module TipTap
   class Error < StandardError; end

--- a/lib/tip_tap/document.rb
+++ b/lib/tip_tap/document.rb
@@ -47,5 +47,11 @@ module TipTap
 
       add_content(Nodes::Codeblock.new(&block))
     end
+
+    def table(&block)
+      raise ArgumentError, "Block required" if block.nil?
+
+      add_content(Nodes::Table.new(&block))
+    end
   end
 end

--- a/lib/tip_tap/nodes/table.rb
+++ b/lib/tip_tap/nodes/table.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "tip_tap/node"
+
+module TipTap
+  module Nodes
+    class Table < Node
+      self.type_name = "table"
+      self.html_tag = :table
+
+      def table_row(&block)
+        raise ArgumentError, "Block required" if block.nil?
+
+        add_content(TableRow.new(&block))
+      end
+    end
+  end
+end

--- a/lib/tip_tap/nodes/table_cell.rb
+++ b/lib/tip_tap/nodes/table_cell.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "tip_tap/node"
+
+module TipTap
+  module Nodes
+    class TableCell < Node
+      self.type_name = "tableCell"
+      self.html_tag = :td
+
+      def paragraph(&block)
+        raise ArgumentError, "Block required" if block.nil?
+
+        add_content(Paragraph.new(&block))
+      end
+    end
+  end
+end

--- a/lib/tip_tap/nodes/table_header.rb
+++ b/lib/tip_tap/nodes/table_header.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "tip_tap/node"
+
+module TipTap
+  module Nodes
+    class TableHeader < Node
+      self.type_name = "tableHeader"
+      self.html_tag = :th
+
+      def paragraph(&block)
+        raise ArgumentError, "Block required" if block.nil?
+
+        add_content(Paragraph.new(&block))
+      end
+    end
+  end
+end

--- a/lib/tip_tap/nodes/table_row.rb
+++ b/lib/tip_tap/nodes/table_row.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "tip_tap/node"
+
+module TipTap
+  module Nodes
+    class TableRow < Node
+      self.type_name = "tableRow"
+      self.html_tag = :tr
+
+      def table_cell(&block)
+        raise ArgumentError, "Block required" if block.nil?
+
+        add_content(TableCell.new(&block))
+      end
+
+      def table_header(&block)
+        raise ArgumentError, "Block required" if block.nil?
+
+        add_content(TableHeader.new(&block))
+      end
+    end
+  end
+end

--- a/lib/tip_tap/version.rb
+++ b/lib/tip_tap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TipTap
-  VERSION = "0.9.7"
+  VERSION = "0.9.8"
 end

--- a/spec/tip_tap/document_spec.rb
+++ b/spec/tip_tap/document_spec.rb
@@ -262,4 +262,45 @@ RSpec.describe TipTap::Document do
       end
     end
   end
+
+  describe "#table" do
+    let(:doc) do
+      TipTap::Document.new do |d|
+        d.table do |t|
+          t.table_row do |r|
+            r.table_header { |h| h.paragraph { |p| p.text "Header" } }
+            r.table_cell { |c| c.paragraph { |p| p.text "Cell" } }
+          end
+        end
+      end
+    end
+
+    it "adds a Table to the document" do
+      expect(doc.content.first).to be_a(TipTap::Nodes::Table)
+    end
+
+    it "correctly structures table-related nodes" do
+      table = doc.content.first
+      expect(table).to be_a(TipTap::Nodes::Table)
+
+      row = table.content.first
+      expect(row).to be_a(TipTap::Nodes::TableRow)
+
+      header = row.content.first
+      expect(header).to be_a(TipTap::Nodes::TableHeader)
+      expect(header.to_plain_text).to eq("Header")
+
+      cell = row.content.last
+      expect(cell).to be_a(TipTap::Nodes::TableCell)
+      expect(cell.to_plain_text).to eq("Cell")
+    end
+
+    it "generates the correct hash structure for table nodes" do
+      table_hash = doc.to_h[:content].first
+
+      expect(table_hash[:type]).to eq("table")
+      expect(table_hash[:content].first[:type]).to eq("tableRow")
+      expect(table_hash[:content].first[:content].map { |node| node[:type] }).to eq(["tableHeader", "tableCell"])
+    end
+  end
 end

--- a/spec/tip_tap/nodes/table_cell_spec.rb
+++ b/spec/tip_tap/nodes/table_cell_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe TipTap::Nodes::TableCell do
+  let(:cell) { described_class.new }
+
+  it "has the correct type_name" do
+    expect(described_class.type_name).to eq("tableCell")
+  end
+
+  it "has the correct html_tag" do
+    expect(described_class.html_tag).to eq(:td)
+  end
+
+  describe "#paragraph" do
+    it "adds a Paragraph to the content" do
+      cell.paragraph { |p| p.text "Test" }
+      expect(cell.content.first).to be_a(TipTap::Nodes::Paragraph)
+    end
+
+    it "raises an ArgumentError when no block is given" do
+      expect { cell.paragraph }.to raise_error(ArgumentError, "Block required")
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation of the cell" do
+      cell.paragraph { |p| p.text "Test" }
+      expect(cell.to_h).to eq({
+        type: "tableCell",
+        content: [
+          {
+            type: "paragraph",
+            content: [{type: "text", text: "Test"}]
+          }
+        ]
+      })
+    end
+  end
+end

--- a/spec/tip_tap/nodes/table_header_spec.rb
+++ b/spec/tip_tap/nodes/table_header_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe TipTap::Nodes::TableHeader do
+  let(:header) { described_class.new }
+
+  it "has the correct type_name" do
+    expect(described_class.type_name).to eq("tableHeader")
+  end
+
+  it "has the correct html_tag" do
+    expect(described_class.html_tag).to eq(:th)
+  end
+
+  describe "#paragraph" do
+    it "adds a Paragraph to the content" do
+      header.paragraph { |p| p.text "Header" }
+      expect(header.content.first).to be_a(TipTap::Nodes::Paragraph)
+    end
+
+    it "raises an ArgumentError when no block is given" do
+      expect { header.paragraph }.to raise_error(ArgumentError, "Block required")
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation of the header" do
+      header.paragraph { |p| p.text "Header" }
+      expect(header.to_h).to eq({
+        type: "tableHeader",
+        content: [
+          {
+            type: "paragraph",
+            content: [{type: "text", text: "Header"}]
+          }
+        ]
+      })
+    end
+  end
+end

--- a/spec/tip_tap/nodes/table_row_spec.rb
+++ b/spec/tip_tap/nodes/table_row_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe TipTap::Nodes::TableRow do
+  let(:row) { described_class.new }
+
+  it "has the correct type_name" do
+    expect(described_class.type_name).to eq("tableRow")
+  end
+
+  it "has the correct html_tag" do
+    expect(described_class.html_tag).to eq(:tr)
+  end
+
+  describe "#table_cell" do
+    it "adds a TableCell to the content" do
+      row.table_cell { |cell| cell.paragraph { |p| p.text "Test" } }
+      expect(row.content.first).to be_a(TipTap::Nodes::TableCell)
+    end
+
+    it "raises an ArgumentError when no block is given" do
+      expect { row.table_cell }.to raise_error(ArgumentError, "Block required")
+    end
+  end
+
+  describe "#table_header" do
+    it "adds a TableHeader to the content" do
+      row.table_header { |header| header.paragraph { |p| p.text "Header" } }
+      expect(row.content.first).to be_a(TipTap::Nodes::TableHeader)
+    end
+
+    it "raises an ArgumentError when no block is given" do
+      expect { row.table_header }.to raise_error(ArgumentError, "Block required")
+    end
+  end
+end

--- a/spec/tip_tap/nodes/table_spec.rb
+++ b/spec/tip_tap/nodes/table_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe TipTap::Nodes::Table do
+  let(:table) { described_class.new }
+
+  it "has the correct type_name" do
+    expect(described_class.type_name).to eq("table")
+  end
+
+  it "has the correct html_tag" do
+    expect(described_class.html_tag).to eq(:table)
+  end
+
+  describe "#table_row" do
+    it "adds a TableRow to the content" do
+      table.table_row do |row|
+        row.table_cell { |cell| cell.paragraph { |p| p.text "Test" } }
+      end
+
+      expect(table.content.first).to be_a(TipTap::Nodes::TableRow)
+    end
+
+    it "raises an ArgumentError when no block is given" do
+      expect { table.table_row }.to raise_error(ArgumentError, "Block required")
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation of the table" do
+      table.table_row do |row|
+        row.table_cell { |cell| cell.paragraph { |p| p.text "Test" } }
+      end
+
+      expect(table.to_h).to eq({
+        type: "table",
+        content: [
+          {
+            type: "tableRow",
+            content: [
+              {
+                type: "tableCell",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{type: "text", text: "Test"}]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
+    end
+  end
+end


### PR DESCRIPTION
### Description
This builds out support for tables.

### Reason/Reference
TipTap's [table extension](https://tiptap.dev/docs/editor/extensions/nodes/table) is a common addition so this will allow for parsing and generating tables according to the schema.
