### PR TITLE
Add `ordered_list` to `TipTap::Document`

### DIFF
--- a/lib/tip_tap/document.rb
+++ b/lib/tip_tap/document.rb
@@ -32,6 +32,12 @@ module TipTap
       add_content(Nodes::BulletList.new(&block))
     end
 
+    def ordered_list(&block)
+      raise ArgumentError, "Block required" if block.nil?
+
+      add_content(Nodes::OrderedList.new(&block))
+    end
+
     def image(src:)
       add_content(Nodes::Image.new(src: src))
     end

--- a/spec/tip_tap/document_spec.rb
+++ b/spec/tip_tap/document_spec.rb
@@ -219,6 +219,22 @@ RSpec.describe TipTap::Document do
     end
   end
 
+  describe "ordered_list" do
+    it "adds an ordered list node" do
+      document = TipTap::Document.new do |document|
+        document.ordered_list do |ol|
+          ol.list_item do |li|
+            li.paragraph do |para|
+              para.text("Hello World!")
+            end
+          end
+        end
+      end
+
+      expect(document.content.first).to be_a(TipTap::Nodes::OrderedList)
+    end
+  end
+
   describe "blockquote" do
     it "adds a blockquote node" do
       document = TipTap::Document.new do |document|


### PR DESCRIPTION
### Description

I've tried rendering both a bullet list and an ordered list (as we use both in our project), and I've noticed that the latter seems to be missing from `TipTap::Document`. This adds support for `ordered_list`.
