### PR TITLE
Update rexml for CVE-2024-49761

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,8 +55,7 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.2)
-    rexml (3.3.6)
-      strscan
+    rexml (3.3.9)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -100,7 +99,6 @@ GEM
     standard-performance (1.2.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.1)
-    strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)

--- a/lib/tip_tap/version.rb
+++ b/lib/tip_tap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TipTap
-  VERSION = "0.9.9"
+  VERSION = "0.9.10"
 end


### PR DESCRIPTION
### Description
Update the rexml gem for CVE-2024-49761 https://github.com/CompanyCam/tiptap-ruby/security/dependabot/9.

### Reason/Reference
Security patch