### PR TITLE
Update Nokogiri for CVE and fix specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.9.13] - 2025-02-19
+
+- require URI explicity in HtmlRenderable
+- Force set platform to ruby for Gemfile.lock
+
 ## [0.9.12] - 2024-12-20
 
 - Add inline styles when converting headings and paragraphs to HTML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.9.13] - 2025-02-19
 
+- Update Nokogiri for CVE
 - require URI explicity in HtmlRenderable
 - Force set platform to ruby for Gemfile.lock
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tiptap-ruby (0.9.12)
+    tiptap-ruby (0.9.13)
       actionview (>= 7.0)
       activesupport (>= 6.0)
 
@@ -47,11 +47,11 @@ GEM
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    mini_portile2 (2.8.8)
     minitest (5.20.0)
     mutex_m (0.3.0)
-    nokogiri (1.16.8-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.8-x86_64-linux)
+    nokogiri (1.18.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
@@ -118,10 +118,7 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   rake (~> 13.0)

--- a/lib/tip_tap/html_renderable.rb
+++ b/lib/tip_tap/html_renderable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_view"
+require "uri"
 
 module TipTap
   module HtmlRenderable

--- a/lib/tip_tap/version.rb
+++ b/lib/tip_tap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TipTap
-  VERSION = "0.9.12"
+  VERSION = "0.9.13"
 end


### PR DESCRIPTION
### Description
- Update Nokogiri for CVE
- Explicitly `require "uri"` in `HtmlRenderable`
- Set `PLATFORM` to `ruby` in `Gemfile.lock` to stop architecture creep

### Reason/Reference
https://github.com/CompanyCam/tiptap-ruby/security/dependabot/15

Closes #39
