### PR TITLE
Update Nokogiri for CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.9.16] - 2025-04-22
+
+- Update Nokogiri for CVE
+
 ## [0.9.15] - 2025-03-05
 
 - Update Nokogiri for CVE

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tiptap-ruby (0.9.15)
+    tiptap-ruby (0.9.16)
       actionview (>= 7.0)
       activesupport (>= 6.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     mini_portile2 (2.8.8)
     minitest (5.20.0)
     mutex_m (0.3.0)
-    nokogiri (1.18.5)
+    nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.23.0)

--- a/lib/tip_tap/version.rb
+++ b/lib/tip_tap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TipTap
-  VERSION = "0.9.15"
+  VERSION = "0.9.16"
 end


### PR DESCRIPTION
### Description
This patches a CVE with Nokogiri by updating to 1.18.8.

### Reason/Reference
https://github.com/CompanyCam/tiptap-ruby/security/dependabot/17
