### PR TITLE
Update Nokogiri for CVE and bump version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tiptap-ruby (0.9.16)
+    tiptap-ruby (0.9.17)
       actionview (>= 7.0)
       activesupport (>= 6.0)
 
@@ -50,7 +50,7 @@ GEM
     mini_portile2 (2.8.8)
     minitest (5.20.0)
     mutex_m (0.3.0)
-    nokogiri (1.18.8)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.23.0)

--- a/lib/tip_tap/version.rb
+++ b/lib/tip_tap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TipTap
-  VERSION = "0.9.16"
+  VERSION = "0.9.17"
 end


### PR DESCRIPTION
### Description
Update Nokogiri to 1.18.9 for CVE and bump version.

### Reason/Reference
https://github.com/CompanyCam/tiptap-ruby/security/dependabot/18
