### PR TITLE
Update Rexml for CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.2)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)


### PR DESCRIPTION
### Description
There is a CVE linked below that is addressed by updating the rexml gem.

### Reason/Reference
Closes #48 
https://github.com/CompanyCam/tiptap-ruby/security/dependabot/19