### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.10.1] - 2025-11-21
+
+- Add support for Table of Contents
+
 ## [0.10.0] - 2025-09-19
 
 - Add support for rendering documents to markdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tiptap-ruby (0.10.0)
+    tiptap-ruby (0.10.1)
       actionview (>= 7.0)
       activesupport (>= 6.0)
 

--- a/lib/tip_tap/version.rb
+++ b/lib/tip_tap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TipTap
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
### Description
Bumps the gem version to 0.10.1 

### Reason/Reference

https://github.com/CompanyCam/tiptap-ruby/pull/51